### PR TITLE
Fixing man formatting for lacroix_palette()

### DIFF
--- a/R/LaCroixColor.R
+++ b/R/LaCroixColor.R
@@ -1,5 +1,7 @@
-#' A LaCriox color palette generator
-#' This function allows you to generate color palettes based on LaCriox water flavors.
+#' A LaCroix color palette generator
+#'
+#' This function allows you to generate color palettes based on LaCroix water flavors.
+#'
 #' @keywords color palettes
 #' @param n: Number of colors desired If omitted, uses all colours.
 #' @param name: Number of colors desired If omitted, uses all colours.
@@ -8,46 +10,46 @@
 #' @examples
 #' lacroix_palette()
 lacroix_palette <- function(name, n, type = c("discrete","continuous","paired")) {
-  
+
   if (missing(type)) {
     type <- "continuous"
   }
-  
+
   type <- match.arg(type)
-  
+
   if(type == "paired") {
-    
+
     pal <- lacroix_palettes[["paired"]]
-    
+
     if (missing(n)) {
       n <- length(pal)
     }
-    
+
     if (n > length(pal)) {
       stop("Number of requested colors greater than what palette can offer")
     }
-    
+
   } else {
-    
+
     pal <- lacroix_palettes[[name]]
     if (is.null(pal))
       stop("Flavor not found!")
-    
+
     if (missing(n)) {
       n <- length(pal[1,])
     }
-    
+
     if (type == "discrete" && n > length(pal[1,])) {
       stop("Number of requested colors greater than what palette can offer")
     }
   }
-  
+
   out <- switch(type,
                 continuous = grDevices::colorRampPalette(pal[1,])(n),
                 discrete = pal[1,][as.numeric(pal[2,1:n])],
                 paired = pal[1:n]
   )
-  
+
   structure(out, class = "palette", name = ifelse(type == "paired", "paired", name))
 }
 #' example: lacroix_palette("MurePepino")

--- a/man/lacroix_palette.Rd
+++ b/man/lacroix_palette.Rd
@@ -2,8 +2,7 @@
 % Please edit documentation in R/LaCroixColor.R
 \name{lacroix_palette}
 \alias{lacroix_palette}
-\title{A LaCriox color palette generator
-This function allows you to generate color palettes based on LaCriox water flavors.}
+\title{A LaCroix color palette generator}
 \usage{
 lacroix_palette(name, n, type = c("discrete", "continuous", "paired"))
 }
@@ -15,8 +14,7 @@ lacroix_palette(name, n, type = c("discrete", "continuous", "paired"))
 \item{type:}{Either "discrete", "continuous", or "paired".}
 }
 \description{
-A LaCriox color palette generator
-This function allows you to generate color palettes based on LaCriox water flavors.
+This function allows you to generate color palettes based on LaCroix water flavors.
 }
 \examples{
 lacroix_palette()


### PR DESCRIPTION
Hi there, thank you for making this package! It brings me great joy :)
I noticed that the roxygen comments for `lacroix_palette()` were not rendering the function title and description separately, so this is a tiny fix for that.