### PR TITLE
Update the parameter documentation for the name parameter

### DIFF
--- a/R/LaCroixColor.R
+++ b/R/LaCroixColor.R
@@ -4,7 +4,7 @@
 #'
 #' @keywords color palettes
 #' @param n: Number of colors desired If omitted, uses all colours.
-#' @param name: Number of colors desired If omitted, uses all colours.
+#' @param name: Name of color palette (LaCroix flavor) desired.
 #' @param type: Either "discrete", "continuous", or "paired".
 #' @export
 #' @examples

--- a/R/print.palette.R
+++ b/R/print.palette.R
@@ -1,6 +1,6 @@
 #' Function to print color palettes
 #' @param n: Number of colors desired If omitted, uses all colours.
-#' @param name: Number of colors desired If omitted, uses all colours.
+#' @param name: Name of color palette (LaCroix flavor) desired.
 #' @export
 print.palette <- function(x, ...) {
    


### PR DESCRIPTION
Thanks for creating this package!

The documentation for the `name` parameter was the same as the `n`parameter. I've fixed this for both `lacroix_palette()` and `print.palette()`.