### PR TITLE
`username` parameter is deprecated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Choose from 20 different LaCroix flavors--quench your thirst!
 ## Install package
 
 `install.packages("devtools")` \
-`devtools::install_github('LaCroixColoR','johannesbjork')`
+`devtools::install_github("johannesbjork/LaCroixColoR")`
 
 ## For discrete palettes
 


### PR DESCRIPTION
# Overview
Updated `README.md` so that it now includes user name in the `repo` argument inside of `devtools::install_github()`.

# Reason
[`devtools`](https://devtools.r-lib.org/) package version 1.13.6 delivers a warning message stating:
> Username parameter is depracted. Please use johannesbjork/LaCroixColoR. 

